### PR TITLE
Switch Button to ItemButton

### DIFF
--- a/EasyDisenchant.lua
+++ b/EasyDisenchant.lua
@@ -186,10 +186,10 @@ do
 
 			cache.factory = function(index)
 				return {
-					type = "BUTTON",
+					type = "ItemButton",
 					parent = self.disenchantFrame,
 					parentName = "ItemButton" .. index,
-					inherit = "ItemButtonTemplate,SecureActionButtonTemplate",
+					inherit = "SecureActionButtonTemplate",
 					textures = {
 						injectSelf = "backdrop",
 						layer = "BACKGROUND",


### PR DESCRIPTION
8.1.5 contains a change that makes ItemButton its own distinct FrameType and eliminates ItemButtonTemplate. 

This PR addresses that issue and restores functionality to the addon. 